### PR TITLE
Exercise: Maps

### DIFF
--- a/41-Maps.go
+++ b/41-Maps.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+    "code.google.com/p/go-tour/wc"
+)
+
+func WordCount(s string) map[string]int {
+    return map[string]int{"x": 1}
+}
+
+func main() {
+    wc.Test(WordCount)
+}

--- a/41-Maps.go
+++ b/41-Maps.go
@@ -1,13 +1,18 @@
 package main
 
 import (
-    "code.google.com/p/go-tour/wc"
+	"code.google.com/p/go-tour/wc"
+	"strings"
 )
 
 func WordCount(s string) map[string]int {
-    return map[string]int{"x": 1}
+	ret := make(map[string]int)
+	for _, c := range strings.Fields(s) {
+		ret[c]++
+	}
+	return ret
 }
 
 func main() {
-    wc.Test(WordCount)
+	wc.Test(WordCount)
 }

--- a/41-Maps.md
+++ b/41-Maps.md
@@ -1,0 +1,6 @@
+Exercise: Maps
+==============
+
+WordCount 関数を実装してみましょう。文字列 s の “word” の数のmapを戻す必要があります。 wc.Test 関数は、引数に渡した関数に対しテストスイートを実行し、成功か失敗かを結果に表示します。
+
+[strings.Fields](http://golang.org/pkg/strings/#Fields) で、何かヒントを得ることができるはずです。


### PR DESCRIPTION
WordCount 関数を実装してみましょう。文字列 s の “word” の数のmapを戻す必要があります。 wc.Test 関数は、引数に渡した関数に対しテストスイートを実行し、成功か失敗かを結果に表示します。

[strings.Fields](http://golang.org/pkg/strings/#Fields) で、何かヒントを得ることができるはずです。
