### PR TITLE
Advanced Exercise: Complex cube roots

### DIFF
--- a/48-Complex-cube-roots.go
+++ b/48-Complex-cube-roots.go
@@ -1,0 +1,10 @@
+package main
+
+import "fmt"
+
+func Cbrt(x complex128) complex128 {
+}
+
+func main() {
+    fmt.Println(Cbrt(2))
+}

--- a/48-Complex-cube-roots.go
+++ b/48-Complex-cube-roots.go
@@ -1,10 +1,19 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"math/cmplx"
+)
 
 func Cbrt(x complex128) complex128 {
+	z := x
+	for i := 0; i < 10; i++ {
+		z = z - (z*z*z-x)/(3*z*z)
+	}
+	return z
 }
 
 func main() {
-    fmt.Println(Cbrt(2))
+	fmt.Println(Cbrt(2))
+	fmt.Println(cmplx.Pow(Cbrt(2), 3))
 }

--- a/48-Complex-cube-roots.md
+++ b/48-Complex-cube-roots.md
@@ -1,0 +1,8 @@
+Advanced Exercise: Complex cube roots
+=====================================
+
+complex64 と complex128 の型による、 Go言語の複素数( complex )について見てみましょう。 立方根( cube root )の場合、ニュートン法は、以下の式を繰り返すことになります：
+
+![](http://go-tour-jp.appspot.com/static/newton3.png)
+
+"2"の立方根を探し、アルゴリズムが正しく動作するか確認してください。 math/cmplx パッケージに [Pow](http://golang.org/pkg/math/cmplx/#Pow) 関数がありますので、結果を確認してみましょう。


### PR DESCRIPTION
complex64 と complex128 の型による、 Go言語の複素数( complex )について見てみましょう。 立方根( cube root )の場合、ニュートン法は、以下の式を繰り返すことになります：

![](http://go-tour-jp.appspot.com/static/newton3.png)

"2"の立方根を探し、アルゴリズムが正しく動作するか確認してください。 math/cmplx パッケージに [Pow](http://golang.org/pkg/math/cmplx/#Pow) 関数がありますので、結果を確認してみましょう。
