### PR TITLE
Exercise: Errors

### DIFF
--- a/56-Errors.go
+++ b/56-Errors.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+    "fmt"
+)
+
+func Sqrt(f float64) (float64, error) {
+    return 0, nil
+}
+
+func main() {
+    fmt.Println(Sqrt(2))
+    fmt.Println(Sqrt(-2))
+}

--- a/56-Errors.go
+++ b/56-Errors.go
@@ -1,14 +1,37 @@
 package main
 
 import (
-    "fmt"
+	"fmt"
+	"math"
 )
 
+type ErrNegativeSqrt float64
+
+func (e ErrNegativeSqrt) Error() string {
+	return fmt.Sprintf("cannot Sqrt negative number: %f", e)
+}
+
 func Sqrt(f float64) (float64, error) {
-    return 0, nil
+	if f < 0 {
+		return 0, ErrNegativeSqrt(f)
+	}
+
+	z := f
+	zz := z + 1
+	epsilon := 0.000001
+
+	t := 0
+	for math.Abs(zz-z) > epsilon {
+		zz = z
+		z = z - (z*z-f)/(2*z)
+		t++
+	}
+	fmt.Printf("times = %d\n", t)
+
+	return z, nil
 }
 
 func main() {
-    fmt.Println(Sqrt(2))
-    fmt.Println(Sqrt(-2))
+	fmt.Println(Sqrt(2))
+	fmt.Println(Sqrt(-2))
 }

--- a/56-Errors.md
+++ b/56-Errors.md
@@ -1,0 +1,26 @@
+Exercise: Errors
+================
+
+Sqrt 関数を以前の演習からコピーし、 error の値を返すように修正してみてください。
+
+Sqrt は、複素数をサポートしていないので、負の値が与えられたとき、nil以外のエラー値を返す必要があります。
+
+新しいタイプの
+
+```go
+type ErrNegativeSqrt float64
+```
+を作成してみてください。
+
+そして、 error ErrNegativeSqrt(-2).String.Error() で、 "cannot Sqrt negative number: -2" を返すような
+
+```go
+func (e ErrNegativeSqrt) Error() string
+```
+メソッドを作ります。
+
+**注意**： Error メソッド中で、 fmt.Print(e) を呼び出すことは、無限ループにプログラムが陥ることでしょう。
+
+最初に、 fmt.Print(float64(e)) として e を変換することより、これを避けることができます。 なぜでしょうか？
+
+負の値が与えられたとき、 ErrNegativeSqrt の値を返すように Sqrt 関数を修正してみてください。


### PR DESCRIPTION
Sqrt 関数を以前の演習からコピーし、 error の値を返すように修正してみてください。

Sqrt は、複素数をサポートしていないので、負の値が与えられたとき、nil以外のエラー値を返す必要があります。

新しいタイプの

``` go
type ErrNegativeSqrt float64
```

を作成してみてください。

そして、 error ErrNegativeSqrt(-2).String.Error() で、 "cannot Sqrt negative number: -2" を返すような

``` go
func (e ErrNegativeSqrt) Error() string
```

メソッドを作ります。

**注意**： Error メソッド中で、 fmt.Print(e) を呼び出すことは、無限ループにプログラムが陥ることでしょう。

最初に、 fmt.Print(float64(e)) として e を変換することより、これを避けることができます。 なぜでしょうか？

負の値が与えられたとき、 ErrNegativeSqrt の値を返すように Sqrt 関数を修正してみてください。
