### PR TITLE
Exercise: Rot13 Reader

### DIFF
--- a/61-Rot13-Reader.go
+++ b/61-Rot13-Reader.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+    "io"
+    "os"
+    "strings"
+)
+
+type rot13Reader struct {
+    r io.Reader
+}
+
+func main() {
+    s := strings.NewReader(
+        "Lbh penpxrq gur pbqr!")
+    r := rot13Reader{s}
+    io.Copy(os.Stdout, &r)
+}

--- a/61-Rot13-Reader.go
+++ b/61-Rot13-Reader.go
@@ -1,18 +1,35 @@
 package main
 
 import (
-    "io"
-    "os"
-    "strings"
+	"io"
+	"os"
+	"strings"
 )
 
 type rot13Reader struct {
-    r io.Reader
+	r io.Reader
+}
+
+func (rot *rot13Reader) Read(p []byte) (n int, err error) {
+	n, err = rot.r.Read(p)
+
+	if err != nil {
+		return
+	}
+
+	for i := 0; i < len(p); i++ {
+		if (p[i] >= 'A' && p[i] <= 'M') || (p[i] >= 'a' && p[i] <= 'm') {
+			p[i] += 13
+		} else if (p[i] >= 'N' && p[i] <= 'Z') || (p[i] >= 'n' && p[i] <= 'z') {
+			p[i] -= 13
+		}
+	}
+	return
 }
 
 func main() {
-    s := strings.NewReader(
-        "Lbh penpxrq gur pbqr!")
-    r := rot13Reader{s}
-    io.Copy(os.Stdout, &r)
+	s := strings.NewReader(
+		"Lbh penpxrq gur pbqr!")
+	r := rot13Reader{s}
+	io.Copy(os.Stdout, &r)
 }

--- a/61-Rot13-Reader.md
+++ b/61-Rot13-Reader.md
@@ -1,0 +1,10 @@
+Exercise: Rot13 Reader
+======================
+
+ある共通のパターンは、[io.Reader](http://golang.org/pkg/io/#Reader)です。 これは、何らかの方法でストリームを変更する別の io.Reader をラップしています。
+
+例えば、 [gzip.NewReader](http://golang.org/pkg/compress/gzip/#NewReader) は、 io.Reader （gzipされたデータのストリーム）を引数で受け取り、 *gzip.Reader を返します。 その *gzip.Reader は、 io.Reader (展開されたデータのストリーム)を実装しています。
+
+io.Reader を実装し、 io.Reader から読み出すように rot13Reader を実装してみてください。 なお、 rot13Reader は、 [ROT13](http://ja.wikipedia.org/wiki/ROT13) 換字式暗号( substitution cipher )をすべてのアルファベットの文字に適用してください。
+
+rot13Reader 型は、みなさんに提供します。 この rot13Reader は、それの Read メソッドを実装することで io.Reader を作成してみてください。


### PR DESCRIPTION
ある共通のパターンは、[io.Reader](http://golang.org/pkg/io/#Reader)です。 これは、何らかの方法でストリームを変更する別の io.Reader をラップしています。

例えば、 [gzip.NewReader](http://golang.org/pkg/compress/gzip/#NewReader) は、 io.Reader （gzipされたデータのストリーム）を引数で受け取り、 *gzip.Reader を返します。 その *gzip.Reader は、 io.Reader (展開されたデータのストリーム)を実装しています。

io.Reader を実装し、 io.Reader から読み出すように rot13Reader を実装してみてください。 なお、 rot13Reader は、 [ROT13](http://ja.wikipedia.org/wiki/ROT13) 換字式暗号( substitution cipher )をすべてのアルファベットの文字に適用してください。

rot13Reader 型は、みなさんに提供します。 この rot13Reader は、それの Read メソッドを実装することで io.Reader を作成してみてください。
